### PR TITLE
Fix syntax issues

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -6,9 +6,10 @@
     "packages": {
         "": {
             "name": "clarity-lsp",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "GPL-3.0-only",
             "dependencies": {
+                "js-yaml": "^3.13.1",
                 "jsonc-parser": "^2.2.1",
                 "node-fetch": "^2.6.1",
                 "vscode-languageclient": "6.1.3"
@@ -343,7 +344,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -904,7 +904,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -1420,7 +1419,6 @@
             "version": "3.13.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
             "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-            "dev": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -2034,8 +2032,7 @@
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "node_modules/string-width": {
             "version": "4.2.0",
@@ -2805,7 +2802,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -3262,8 +3258,7 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "esquery": {
             "version": "1.2.0",
@@ -3670,7 +3665,6 @@
             "version": "3.13.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
             "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -4164,8 +4158,7 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "string-width": {
             "version": "4.2.0",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -39,11 +39,13 @@
         "package": "vsce package -o clarity-lsp.vsix",
         "compile": "tsc -b",
         "build": "tsc",
+        "build:syntax": "js-yaml syntaxes/clarity.yaml > syntaxes/clarity.tmLanguage.json",
         "watch": "tsc --watch",
         "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src",
         "fix": "tsfmt -r && eslint -c .eslintrc.js --ext ts ./src --fix"
     },
     "dependencies": {
+        "js-yaml": "^3.13.1",
         "jsonc-parser": "^2.2.1",
         "node-fetch": "^2.6.1",
         "vscode-languageclient": "6.1.3"

--- a/editors/code/syntaxes/clarity.tmLanguage.json
+++ b/editors/code/syntaxes/clarity.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "scopeName": "source.clar",
-  "uuid": "f9e9871d-2ea6-4be0-afd2-fc382d704716",
+  "uuid": "f09c317d-fb99-410f-b88e-7272bb2af68d",
   "patterns": [
     {
       "include": "#comment"

--- a/editors/code/syntaxes/clarity.tmLanguage.json
+++ b/editors/code/syntaxes/clarity.tmLanguage.json
@@ -1,6 +1,6 @@
 {
-  "name": "clarity2",
-  "scopeName": "source.clarity",
+  "name": "clarity",
+  "scopeName": "source.clar",
   "uuid": "f9e9871d-2ea6-4be0-afd2-fc382d704716",
   "patterns": [
     {
@@ -119,7 +119,7 @@
       ]
     },
     "define-func": {
-      "begin": "(?x)\n  (?<=^|[(]) \\s*\n  (define-(?:public|private|read-only)) \\s+\n  (\\() \\s*\n  ([a-z][a-zA-Z0-9_-]+) \\s*\n",
+      "begin": "(?x)\n  (?<=^|[(]) \\s*\n  (define-(?:public|private|read-only)) \\s+\n  (\\() \\s*\n  ([a-z][a-zA-Z0-9_-]*) \\s*\n",
       "beginCaptures": {
         "1": {
           "name": "storage.type.clarity"
@@ -144,7 +144,7 @@
       ]
     },
     "define-var": {
-      "match": "(?x)\n  (?<=^[(]) \\s*\n  (define-(?:constant|data-var|map|fungible-token|non-fungible-token|trait)) \\s+\n  ([a-zA-Z][a-zA-Z0-9_-]+)\n",
+      "match": "(?x)\n  (?<=^[(]) \\s*\n  (define-(?:constant|data-var|map|fungible-token|non-fungible-token|trait)) \\s+\n  ([a-zA-Z][a-zA-Z0-9_-]*)\n",
       "captures": {
         "1": {
           "name": "storage.type.clarity"
@@ -156,10 +156,10 @@
     },
     "tuple-key": {
       "name": "entity.name.type.clarity",
-      "match": "(?x)\n  ([a-z][a-zA-Z0-9_-]+)(?=:)\n"
+      "match": "(?x)\n  ([a-z][a-zA-Z0-9_-]*)(?=:)\n"
     },
     "args": {
-      "begin": "(?x)\n  (?<=^|[(]) \\s*\n  ([a-z][a-zA-Z0-9_-]+) \\s*\n",
+      "begin": "(?x)\n  (?<=^|[(]) \\s*\n  ([a-z][a-zA-Z0-9_-]*) \\s*\n",
       "beginCaptures": {
         "0": {
           "name": "variable.parameter.clarity"

--- a/editors/code/syntaxes/clarity.yaml
+++ b/editors/code/syntaxes/clarity.yaml
@@ -113,7 +113,7 @@ repository:
         (?<=^|[(]) \s*
         (define-(?:public|private|read-only)) \s+
         (\() \s*
-        ([a-z][a-zA-Z0-9_-]+) \s*
+        ([a-z][a-zA-Z0-9_-]*) \s*
     beginCaptures:
       "1":
         name: storage.type.clarity
@@ -133,7 +133,7 @@ repository:
       (?x)
         (?<=^[(]) \s*
         (define-(?:constant|data-var|map|fungible-token|non-fungible-token|trait)) \s+
-        ([a-zA-Z][a-zA-Z0-9_-]+)
+        ([a-zA-Z][a-zA-Z0-9_-]*)
     captures:
       "1":
         name: storage.type.clarity
@@ -144,13 +144,13 @@ repository:
     name: entity.name.type.clarity
     match: |
       (?x)
-        ([a-z][a-zA-Z0-9_-]+)(?=:)
+        ([a-z][a-zA-Z0-9_-]*)(?=:)
       
   args:
     begin: |
       (?x)
         (?<=^|[(]) \s*
-        ([a-z][a-zA-Z0-9_-]+) \s*
+        ([a-z][a-zA-Z0-9_-]*) \s*
     beginCaptures:
       "0":
         name: variable.parameter.clarity

--- a/editors/code/syntaxes/clarity.yaml
+++ b/editors/code/syntaxes/clarity.yaml
@@ -1,6 +1,6 @@
 name: clarity
 scopeName: source.clar
-uuid: f9e9871d-2ea6-4be0-afd2-fc382d704716
+uuid: f09c317d-fb99-410f-b88e-7272bb2af68d
 
 patterns:
  - include: "#comment"


### PR DESCRIPTION
This PR fixes few important syntax issues.

1. It enable highlighting of one char long names.
2. Fixes incorrectly compiles/set language name and scope.
3. Adds unique UUID generated with `$ uuidgen -r` command. The original one was exactly the same as the one used in my extension.

Please remember that syntax is build based on `clarity.yaml` using `npm run build:syntax` command.
I'm not sure if this new command should be somehow incorporated into the overall build pipeline, therefore I only added it to `package.json` file.
