### PR TITLE
Fix CI release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,7 +248,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: contains(github.ref, 'main')
     needs:
       - audit
       - dist

--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
     },
     "release": {
         "branches": [
-            {
-                "name": "develop",
-                "prerelease": true
-            },
             "main"
         ],
         "plugins": [


### PR DESCRIPTION
It is currently creating a release for any PRs merged to develop. It should only do this when a PR is merged to main.