### PR TITLE
fix: bump version number

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -58,5 +58,3 @@ cargo xtask install
 - [ ] Resolve contract-call targeting deployed contracts
 - [x] Support for traits
 - [ ] Support for multiple errors
-
-


### PR DESCRIPTION
This is an attempt to trigger the CI to try again to release with the
next version number.