### PR TITLE
ci: ignore audit error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run audit
-        run: cargo audit --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2018-0015 --ignore RUSTSEC-2021-0124 --ignore RUSTSEC-2021-0119
+        run: cargo audit --ignore RUSTSEC-2021-0076 --ignore RUSTSEC-2018-0015 --ignore RUSTSEC-2021-0124 --ignore RUSTSEC-2021-0119 --ignore RUSTSEC-2022-0013
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
This rust code is no longer used, so for now, just ignore the error.
Later, this code will be removed.