### PR TITLE
fix: highlighting escaped characters

### DIFF
--- a/syntaxes/clarity.tmLanguage.json
+++ b/syntaxes/clarity.tmLanguage.json
@@ -258,7 +258,13 @@
               "end": "\"",
               "endCaptures": {
                 "1": { "name": "punctuation.definition.string.end.clarity" }
-              }
+              },
+              "patterns": [ 
+                {
+                  "name": "constant.character.escape.quote",
+                  "match": "\\\\."
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
This PR fixes broken highlighting for escaped characters in strings.

Before:
![image](https://user-images.githubusercontent.com/829210/177374171-2f48c15d-ccd5-403e-8a07-ac9d45d0369f.png)

After:
![image](https://user-images.githubusercontent.com/829210/177374366-33fd41bd-342c-41d3-929f-7099e1d625e2.png)

Discovered while working on: 

- https://github.com/LNow/clarity-projects/commit/8bf6f595238361a5d2fd8a450e6097d25c95acc6
- https://discord.com/channels/621759717756370964/713087894260023377/993901115680763904

Replace #113 